### PR TITLE
Implement a modal

### DIFF
--- a/index.css
+++ b/index.css
@@ -161,33 +161,45 @@ body {
     margin: 0.2em 0;
 }
 
+/* Modal Style */
 div.modal {
-    position: absolute;
     display: none;
     border-radius: 0.2em;
+    border-color: var(--primary);
+    border-style: solid;
     min-width: 8em;
     min-height: 4em;
-    background-color: #3A3B3C;
+    background-color: var(--bg-secondary);
+    z-index: 500;
+}
+
+div.modal.center {
+    position: absolute;
     left: 50%;
     top: 50%;
     transform: translate(-50%, -50%);
 }
+
 div.modal label {
     padding-left: 0.2em;
     padding-top: 0.2em;
     max-height: 1em;
 }
+
 div.modal input[type=text] {
     margin: 0.7em 0.7em 0.7em 0.7em;
     max-height: 1.5em;
 }
+
 div.modal input[type=button] {
     margin: 0em 0.7em 0.7em 0.7em;
     margin-left: auto;
 }
+
 div.modal input[type=button]:last-child {
     margin: 0em 0.7em 0.7em 0em;
 }
+
 div.modal div {
     display: flex;
 }

--- a/index.css
+++ b/index.css
@@ -161,6 +161,37 @@ body {
     margin: 0.2em 0;
 }
 
+div.modal {
+    position: absolute;
+    display: none;
+    border-radius: 0.2em;
+    min-width: 8em;
+    min-height: 4em;
+    background-color: #3A3B3C;
+    left: 50%;
+    top: 50%;
+    transform: translate(-50%, -50%);
+}
+div.modal label {
+    padding-left: 0.2em;
+    padding-top: 0.2em;
+    max-height: 1em;
+}
+div.modal input[type=text] {
+    margin: 0.7em 0.7em 0.7em 0.7em;
+    max-height: 1.5em;
+}
+div.modal input[type=button] {
+    margin: 0em 0.7em 0.7em 0.7em;
+    margin-left: auto;
+}
+div.modal input[type=button]:last-child {
+    margin: 0em 0.7em 0.7em 0em;
+}
+div.modal div {
+    display: flex;
+}
+
 .noun-form {
     display: flex;
     flex-direction: row;

--- a/index.html
+++ b/index.html
@@ -17,6 +17,14 @@
 
 <body onload="onLoad()">
     <div class="page-wrapper">
+        <div class="modal">
+            <label for="modal-input"></label>
+            <input type="text" id="modal-input">
+            <div>
+                <input type="button" value="Submit">
+                <input type="button" value="Cancel">
+            </div>
+        </div>
         <div class="options">
             <select class="dropdown" id="categories" onchange="selectCategory(this.value)">
                 <option value="select" selected hidden>--Category--</option>

--- a/index.html
+++ b/index.html
@@ -17,7 +17,7 @@
 
 <body onload="onLoad()">
     <div class="page-wrapper">
-        <div class="modal">
+        <div class="modal center">
             <label for="modal-input"></label>
             <input type="text" id="modal-input">
             <div>

--- a/index.js
+++ b/index.js
@@ -139,7 +139,7 @@ function selectCategory(category) {
     // Show nounself form if needed
     const nounForm = document.getElementById("noun-form");
     nounForm.style.display = category === "nounself" ? null : "none";
-    
+
     // Show/populate preset dropdown if a category is selected
     const presetDropdown = document.getElementById("presets");
 
@@ -171,6 +171,39 @@ function selectCategory(category) {
 
         presetDropdown.style.display = "block";
     }
+}
+
+// Display the modal with a provided title
+function displayModal(title) {
+    const modal = document.getElementsByClassName("modal")[0];
+    // Check that the modal exists
+    if (modal == undefined) {
+        throw "ERROR: Failed to find modal";
+    }
+
+    // Set the label to the requested title
+    const label = modal.firstElementChild;
+    label.innerHTML = title;
+
+    // Make the modal appear
+    modal.style.display = "inline-grid";
+
+    // Set the input field to be focused
+    const input = modal.getElementsByTagName("input")[0];
+    input.focus();
+}
+
+// Reset the modal to it's default state with a blank label, input and hidden
+function resetModal() {
+    const modal = document.getElementsByClassName("modal")[0];
+    if (modal == undefined) {
+        throw "ERROR: Failed to find modal";
+    }
+    const label = modal.firstElementChild;
+    label.innerHTML = "";
+    const input = modal.getElementsByTagName("input")[0];
+    input.value = "";
+    modal.style.display = "none";
 }
 
 function addCustomCategory(text) {

--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@ const PRONOUNFIELDS = ["subjective", "objective", "possessiveDeterminer", "posse
 const VERB_REGEX = /\{([^\{\}]+?)\/([^\{\}]+?)\}/gi;
 
 class Modal {
+    // Element must have a label, a text input field, a button for submit and a button for cancel, in that order
     constructor(title, element) {
         this.hidden = true;
         this.title = title;

--- a/index.js
+++ b/index.js
@@ -1,6 +1,78 @@
 const PRONOUNFIELDS = ["subjective", "objective", "possessiveDeterminer", "possessive", "reflexive"];
 const VERB_REGEX = /\{([^\{\}]+?)\/([^\{\}]+?)\}/gi;
 
+class Modal {
+    constructor(title, element) {
+        this.hidden = true;
+        this.title = title;
+        if (element == undefined || !element instanceof HTMLDivElement) {
+            throw "ERROR: Failed to find modal element";
+        }
+        this.element = element;
+        this.input = element.getElementsByTagName("input")[0];
+        this.submit = element.getElementsByTagName("input")[1];
+        this.cancel = element.getElementsByTagName("input")[2];
+        this.label = element.firstElementChild;
+        this.label.innerHTML = this.title;
+        // Call hide when cancel button is pressed
+        this.cancel.addEventListener("click", _ => {
+            this.hide();
+        });
+        // Call hide when the escape key is pressed
+        this.element.addEventListener("keydown", evt => {
+            if (evt.keyCode === 27) {
+                this.hide();
+            }
+        });
+    }
+
+    /*
+     * Handle submit events
+     * Example:
+     * const modal = new Modal("Noun:", document.getElementsByClassName("modal")[0]);
+     * modal.onSubmit((evt) => {
+     *     console.log(modal.input.value);
+     * });
+    */
+    onSubmit(callback) {
+        // Call callback when submit button is pressed
+        this.submit.addEventListener("click", callback);
+        // Call callback when enter key is pressed
+        this.element.addEventListener("keydown", evt => {
+            if (evt.keyCode === 13) {
+                callback(evt);
+            }
+        });
+    }
+
+    // Display the modal with a provided title
+    display() {
+        const modal = this.element;
+        // Check that the modal exists and is a div
+        if (modal == undefined || !modal instanceof HTMLDivElement) {
+            throw "ERROR: Failed to find modal element";
+        }
+        // Set the label to the requested title
+        this.label.innerHTML = this.title;
+        // Make the modal appear
+        modal.style.display = "inline-grid";
+        // Set the input field to be focused
+        this.input.focus();
+    }
+
+    // Hide and Reset the modal to it's default state with a blank label, input and hidden
+    hide() {
+        const modal = this.element;
+        if (modal == undefined || !modal instanceof HTMLDivElement) {
+            throw "ERROR: Failed to find modal";
+        }
+        modal.style.display = "none";
+        // Doing this means that multiple Modal objects can make use of a single Modal
+        // if you wanted to
+        this.input.value = "";
+    }
+}
+
 /*--Generic utility functions--*/
 function shuffle(array) {
     /* https://stackoverflow.com/a/46545530 */
@@ -171,39 +243,6 @@ function selectCategory(category) {
 
         presetDropdown.style.display = "block";
     }
-}
-
-// Display the modal with a provided title
-function displayModal(title) {
-    const modal = document.getElementsByClassName("modal")[0];
-    // Check that the modal exists
-    if (modal == undefined) {
-        throw "ERROR: Failed to find modal";
-    }
-
-    // Set the label to the requested title
-    const label = modal.firstElementChild;
-    label.innerHTML = title;
-
-    // Make the modal appear
-    modal.style.display = "inline-grid";
-
-    // Set the input field to be focused
-    const input = modal.getElementsByTagName("input")[0];
-    input.focus();
-}
-
-// Reset the modal to it's default state with a blank label, input and hidden
-function resetModal() {
-    const modal = document.getElementsByClassName("modal")[0];
-    if (modal == undefined) {
-        throw "ERROR: Failed to find modal";
-    }
-    const label = modal.firstElementChild;
-    label.innerHTML = "";
-    const input = modal.getElementsByTagName("input")[0];
-    input.value = "";
-    modal.style.display = "none";
 }
 
 function addCustomCategory(text) {


### PR DESCRIPTION
This implements an input modal to allow for customized text input.
It replaces the prompt for Nounself currently.
Title can be customized.
Input can be submitted either via a submit button or the enter key.
Input can be cancelled either by the cancel button or the escape key.
CSS should be easy to understand if you want to change the colours and everything about it.